### PR TITLE
Lighting proposal

### DIFF
--- a/carts/picocad_player.p8
+++ b/carts/picocad_player.p8
@@ -280,7 +280,9 @@ function make_cam()
       for _,poly in ipairs(polys) do
         --
         local face=poly.face
-        local light=mid(-v_dot(sun,face.n),-1,1)
+        local light=mid(-v_dot(sun,face.n),0.0,1)
+        -- TY - adjust lighting - overbrighten to preserve original colours, clamp the end result to min 0.2 to avoid crushing anything to black
+        light = min( (light * light) * 8 + 0.2, 1 )
         if light>0 then
           pal(_dithers[flr(12*(1-light))],2)
 


### PR DESCRIPTION
Proposing a change to lighting - because the lighting is parallel its rare for faces to be fully lit, the result is that the original colours are typically not preserved (the pallete is obviously very limited which doesn't help). This change overbrights the lighting calculation to mantain the original colours and clamps the minimum colour to avoid flat blacks 

It's an aesthetic change but I think this is closer to the original picoCAD rendering

![image](https://user-images.githubusercontent.com/14915508/145261778-9b10f268-09d7-4521-a390-55a037532d2a.png)
![image](https://user-images.githubusercontent.com/14915508/145261817-c7c7490c-0711-450b-b199-4bd9ef05b546.png)
![image](https://user-images.githubusercontent.com/14915508/145261826-806d3825-dff4-4d24-a7fc-13536a11dcdb.png)
